### PR TITLE
Use "shell" instead of "shell-session" as language directive in examples 

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,8 @@ foo
 
 Taking you into the shell ...
 
+Enter `!!` to rerun the last command.
+
 $
 ```
 

--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ Making sure that example still works over the years is painfully hard.
 
 Not anymore.
 
-```shell-session
+```console
 $ tesh demo/
 📄 Checking demo/happy.md
   ✨ Running foo  ✅ Passed
@@ -56,10 +56,10 @@ $
 
 To mark a code block as testable, append `tesh-session="NAME"` to the header line.
 
-You can use any syntax highlighting directives like `shell-session` or `console`.
+You can use any syntax highlighting directive, such as `bash`, `shell`, `shell-session`, `console` or others.
 
 ~~~
-```shell-session tesh-session="hello"
+```console tesh-session="hello"
 $ echo "Hello World!"
 Hello World!
 ```
@@ -70,14 +70,14 @@ Hello World!
 Besides marking a code block as testable, `tesh-session` is a unique identifier that allows for multiple code blocks to share the same session.
 
 ~~~
-```shell-session tesh-session="multiple_blocks"
+```console tesh-session="multiple_blocks"
 $ export NAME=Earth
 
 ```
 ~~~
 
 ~~~
-```shell-session tesh-session="multiple_blocks"
+```console tesh-session="multiple_blocks"
 $ echo "Hello $NAME!"
 Hello Earth!
 ```
@@ -88,7 +88,7 @@ Hello Earth!
 Parts of the inline output can be ignored with `...`:
 
 ~~~
-```shell-session tesh-session="ignore"
+```console tesh-session="ignore"
 $ echo "Hello from Space!"
 Hello ... Space!
 ```
@@ -97,7 +97,7 @@ Hello ... Space!
 The same can be done for multiple lines of output. Note that trailing whitespace in every line is trimmed.
 
 ~~~
-```shell-session tesh-session="ignore"
+```console tesh-session="ignore"
 $ printf "Hello \nthere \nfrom \nSpace!"
 Hello
 ...
@@ -122,7 +122,7 @@ Let's look at all of these through examples
 `tesh-exitcodes` accepts a list of integers, which represent the exit code for every command in the block.
 
 ~~~
-```shell-session tesh-session="exitcodes" tesh-exitcodes="1 0"
+```console tesh-session="exitcodes" tesh-exitcodes="1 0"
 $ false
 
 $ true
@@ -136,7 +136,7 @@ $ true
 Sometimes you need to do some test setup before running the examples in your code blocks. Put those [in a file](./readme.sh) and point to it with the `tesh-setup` directive.
 
 ~~~
-```shell-session tesh-session="setup" tesh-setup="readme.sh"
+```console tesh-session="setup" tesh-setup="readme.sh"
 $ echo "Hello $NAME!"
 Hello Gaea!
 ```
@@ -148,7 +148,7 @@ Hello Gaea!
 Every so often you need to drop into a virtualenv or similar shell that changes the prompt. `tesh` supports this via `test-ps1` directive.
 
 ~~~
-```shell-session tesh-session="prompt" tesh-ps1="(foo) $"
+```console tesh-session="prompt" tesh-ps1="(foo) $"
 $ PS1="(foo) $ "
 
 
@@ -162,14 +162,14 @@ hello
 Some examples should only run on certain platforms, use `tesh-platform` to declare them as such.
 
 ~~~
-```shell-session tesh-session="platform" tesh-platform="linux"
+```console tesh-session="platform" tesh-platform="linux"
 $ uname
 ...Linux...
 ```
 ~~~
 
 ~~~
-```shell-session tesh-session="platform" tesh-platform="darwin"
+```console tesh-session="platform" tesh-platform="darwin"
 $ uname
 ...Darwin...
 ```
@@ -186,7 +186,7 @@ echo "foo"
 ~~~
 
 ~~~
-```shell-session tesh-session="fixture"
+```console tesh-session="fixture"
 $ chmod +x foo.sh
 
 $ ./foo.sh

--- a/demo/happy.md
+++ b/demo/happy.md
@@ -1,11 +1,11 @@
 # Happy path
 
-```shell-session tesh-session="foo"
+```console tesh-session="foo"
 $ echo "foo"
 foo
 ```
 
-```shell-session tesh-session="bar"
+```console tesh-session="bar"
 $ echo "bar"
 bar
 ```

--- a/demo/sad.md
+++ b/demo/sad.md
@@ -1,6 +1,6 @@
 # Sad panda :(
 
-```shell-session tesh-session="foo"
+```console tesh-session="foo"
 $ echo "foo"
 sad panda
 ```

--- a/src/tesh/test.py
+++ b/src/tesh/test.py
@@ -110,6 +110,8 @@ def invoke_debug(shell: pexpect.spawn, block: Block) -> None:  # pragma: no cove
     print()
     print("Taking you into the shell ...")
     print()
+    print("Enter `!!` to rerun the last command.")
+    print()
     print(block.prompt, end="")
     shell.interact()
 

--- a/src/tesh/tests/fixtures/debug.md
+++ b/src/tesh/tests/fixtures/debug.md
@@ -1,6 +1,6 @@
 # Drop into an interactive shell on error
 
-```shell-session tesh-session="foo"
+```console tesh-session="foo"
 $ echo "foo"
 bar
 ```

--- a/src/tesh/tests/fixtures/exitcodes.md
+++ b/src/tesh/tests/fixtures/exitcodes.md
@@ -1,13 +1,13 @@
 # A Markdown using exitcodes
 
-```shell-session tesh-session="foo" tesh-exitcodes="1 0"
+```console tesh-session="foo" tesh-exitcodes="1 0"
 $ false
 
 $ true
 
 ```
 
-```shell-session tesh-session="bar" tesh-exitcodes="0"
+```console tesh-session="bar" tesh-exitcodes="0"
 $ false
 
 ```

--- a/src/tesh/tests/fixtures/exitcodes_multipleblocks.md
+++ b/src/tesh/tests/fixtures/exitcodes_multipleblocks.md
@@ -1,13 +1,13 @@
 # If you're using exit codes for a session, you must specify them for all commands
 
-```shell-session tesh-session="foo" tesh-exitcodes="1 0"
+```console tesh-session="foo" tesh-exitcodes="1 0"
 $ false
 
 $ true
 
 ```
 
-```shell-session tesh-session="foo"
+```console tesh-session="foo"
 $ echo "foo"
 foo
 ```

--- a/src/tesh/tests/fixtures/fail.md
+++ b/src/tesh/tests/fixtures/fail.md
@@ -1,6 +1,6 @@
 # A Markdown where expected output does not match actual output
 
-```shell-session tesh-session="foo"
+```console tesh-session="foo"
 $ echo "foo"
 bar
 ```

--- a/src/tesh/tests/fixtures/fixture.md
+++ b/src/tesh/tests/fixtures/fixture.md
@@ -4,7 +4,7 @@
 1 + 1
 ```
 
-```shell-session tesh-session="foo"
+```console tesh-session="foo"
 $ cat foo.py
 1 + 1
 ```

--- a/src/tesh/tests/fixtures/folder/simple.md
+++ b/src/tesh/tests/fixtures/folder/simple.md
@@ -1,6 +1,6 @@
 # A simple Markdown file
 
-```shell-session tesh-session="foo"
+```console tesh-session="foo"
 $ echo "foo"
 foo
 ```

--- a/src/tesh/tests/fixtures/multiple_codeblocks.md
+++ b/src/tesh/tests/fixtures/multiple_codeblocks.md
@@ -1,19 +1,19 @@
 # A Markdown file with multiple shell sessions
 
 
-```shell-session tesh-session="foo"
+```console tesh-session="foo"
 $ echo "foo"
 foo
 ```
 
 
-```shell-session tesh-session="foo"
+```console tesh-session="foo"
 $ echo "bar"
 bar
 ```
 
 
-```shell-session tesh-session="foo"
+```console tesh-session="foo"
 $ echo "foo with empty line"
 foo with empty line
 

--- a/src/tesh/tests/fixtures/prompt.md
+++ b/src/tesh/tests/fixtures/prompt.md
@@ -1,7 +1,7 @@
 # A Markdown file that uses tesh-ps1
 
 
-```shell-session tesh-session="foo" tesh-ps1="(foo) $"
+```console tesh-session="foo" tesh-ps1="(foo) $"
 $ PS1="(foo) $ "
 
 (foo) $ echo "bar"

--- a/src/tesh/tests/fixtures/setup.md
+++ b/src/tesh/tests/fixtures/setup.md
@@ -1,7 +1,7 @@
 # A Markdown file that uses tesh-setup
 
 
-```shell-session tesh-session="foo" tesh-setup="setup.sh"
+```console tesh-session="foo" tesh-setup="setup.sh"
 $ echo $FOO
 bar
 ```

--- a/src/tesh/tests/fixtures/setup_fail.md
+++ b/src/tesh/tests/fixtures/setup_fail.md
@@ -1,7 +1,7 @@
 # tesh-setup pointing to an file that does not exist
 
 
-```shell-session tesh-session="foo" tesh-setup="does_not_exist.sh"
+```console tesh-session="foo" tesh-setup="does_not_exist.sh"
 $ echo $FOO
 bar
 ```

--- a/src/tesh/tests/fixtures/timeout.md
+++ b/src/tesh/tests/fixtures/timeout.md
@@ -1,6 +1,6 @@
 # Drop into an interactive shell on timeout
 
-```shell-session tesh-session="foo"
+```console tesh-session="foo"
 $ sleep 35
 foo
 ```


### PR DESCRIPTION
* Makes syntax highlighting more likely to work.
* Less is more.


Also, tell users to use `!!` to rerun the last command in debug prompt.