### PR TITLE
fix: escape square brackets in fnmatch patterns

### DIFF
--- a/src/tesh/test.py
+++ b/src/tesh/test.py
@@ -101,6 +101,7 @@ def get_expected_output(block: Block) -> str:
     """Massage expected output to be able to compare it."""
     expected_output = (
         "\n".join(block.output)
+        .replace("[", "[[]")
         .replace("*", "[*]")
         .replace("?", "[?]")
         .replace("...", "*")

--- a/src/tesh/tests/fixtures/wildcards.md
+++ b/src/tesh/tests/fixtures/wildcards.md
@@ -1,0 +1,6 @@
+# Use ... to match unimportant parts of expected output
+
+```console tesh-session="foo"
+$ echo '{"a":"yes",b:[1,2,3]}'
+{"a":"yes",b:[...]}
+```

--- a/src/tesh/tests/test_tesh.py
+++ b/src/tesh/tests/test_tesh.py
@@ -321,3 +321,22 @@ def test_multiline_command() -> None:
     # fmt: on
 
     assert expected == result.output
+
+
+def test_wildcards() -> None:
+    """Test using ... to ignore parts of the output."""
+    runner = CliRunner()
+    result = runner.invoke(tesh, "src/tesh/tests/fixtures/wildcards.md")
+
+    assert result.exit_code == 0
+
+    # fmt: off
+    expected = (
+"""
+📄 Checking src/tesh/tests/fixtures/wildcards.md
+  ✨ Running foo  ✅ Passed
+"""
+    ).lstrip("\n")
+    # fmt: on
+
+    assert expected == result.output


### PR DESCRIPTION
Example outputs containing square brackets (e.g. JSON arrays) were not matching because the square brackets were interpreted as fnmatch pattern groups. To fix this, we now escape `[` in addition to `*` and `?`.