### PR TITLE
fix: handle unicode in examples

### DIFF
--- a/src/tesh/test.py
+++ b/src/tesh/test.py
@@ -17,6 +17,7 @@ def test(filename: str, session: ShellSession, verbose: bool, debug: bool) -> No
     with Path(filename).parent:
         shell = pexpect.spawn(
             "bash --norc --noprofile",
+            encoding="utf-8",
             env={"PS1": "$ ", "PATH": os.environ["PATH"], "HOME": os.getcwd()},
         )
         shell.expect(r"\$ ")
@@ -68,7 +69,8 @@ def test(filename: str, session: ShellSession, verbose: bool, debug: bool) -> No
             shell.sendline("echo $?")
             shell.expect("echo [$][?]")
             shell.expect(re.escape(prompt))
-            exitcode = int(shell.before.decode("utf-8").strip())
+            assert isinstance(shell.before, str)
+            exitcode = int(shell.before.strip())
             if session.exitcodes and exitcode != session.exitcodes[index]:
                 print("❌ Failed")  # noqa: ENC100
                 print("         Command:", block.command)
@@ -83,7 +85,8 @@ def test(filename: str, session: ShellSession, verbose: bool, debug: bool) -> No
 
 def get_actual_output(shell: pexpect.spawn) -> str:
     """Massage shell output to be able to compare it."""
-    actual_output = shell.before.decode("utf-8").strip().replace("\r\n", "\n")
+    assert isinstance(shell.before, str)
+    actual_output = shell.before.strip().replace("\r\n", "\n")
     return "\n".join([line.rstrip() for line in actual_output.split("\n")])
 
 

--- a/src/tesh/tests/fixtures/folder/simple.md
+++ b/src/tesh/tests/fixtures/folder/simple.md
@@ -1,6 +1,6 @@
 # A simple Markdown file
 
 ```console tesh-session="foo"
-$ echo "foo"
-foo
+$ echo "foo ✨"
+foo ✨
 ```

--- a/src/tesh/tests/test_tesh.py
+++ b/src/tesh/tests/test_tesh.py
@@ -73,8 +73,8 @@ def test_verbose() -> None:
 """
 📄 Checking src/tesh/tests/fixtures/folder/simple.md
   ✨ Running foo  :
-       Command: echo "foo"
-       Output: ['foo']
+       Command: echo "foo ✨"
+       Output: ['foo ✨']
 ✅ Passed
 """
     ).lstrip("\n")
@@ -148,18 +148,20 @@ foo
 
 def test_debug() -> None:  # pragma: no cover
     """Test dropping into an interactive shell on error."""
-    shell = pexpect.spawn("tesh src/tesh/tests/fixtures/debug.md")
+    shell = pexpect.spawn("tesh src/tesh/tests/fixtures/debug.md", encoding="utf-8")
     shell.expect("Taking you into the shell ...")
 
-    assert "✨ Running foo  ❌ Failed".encode() in shell.before
+    assert isinstance(shell.before, str)
+    assert "✨ Running foo  ❌ Failed" in shell.before
 
 
 def test_timeout() -> None:  # pragma: no cover
     """Test dropping into an interactive shell on timeout."""
-    shell = pexpect.spawn("tesh src/tesh/tests/fixtures/timeout.md")
+    shell = pexpect.spawn("tesh src/tesh/tests/fixtures/timeout.md", encoding="utf-8")
     shell.expect("Taking you into the shell ...", timeout=60)
 
-    assert "✨ Running foo  ❌ Timed out after 1s".encode() in shell.before
+    assert isinstance(shell.before, str)
+    assert "✨ Running foo  ❌ Timed out after 1s" in shell.before
 
 
 def test_exitcodes() -> None:


### PR DESCRIPTION
Non-ascii values in examples were causing UnicodeEncodeError. To fix this we enable pexpect's unicode mode by providing the encoding argument when creating pexpect.spawn instances.