### PR TITLE
feat: allow commands to continue across lines

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,17 @@ Space!
 ```
 ~~~
 
+Commands can continue across multiple lines by prefixing lines with `> `.
+
+~~~
+```console tesh-session="ignore"
+$ echo "Hello from" \
+>   "another" \
+>   "line!"
+Hello from another line!
+```
+~~~
+
 ## Advanced directives
 
 You can set a few other optional directives in the header line:

--- a/src/tesh/extract.py
+++ b/src/tesh/extract.py
@@ -181,6 +181,8 @@ def extract_blocks(session: ShellSession, verbose: bool) -> None:
                 r"^" + get_prompt_regex(session), "", line
             ).strip()
             new_block.prompt = m.group(0)
+        elif m := re.match("^> (.*)$", line):
+            new_block.command += f"\n{m.group(1)}"
         elif not line.strip():
             continue
         else:

--- a/src/tesh/test.py
+++ b/src/tesh/test.py
@@ -37,7 +37,8 @@ def test(filename: str, session: ShellSession, verbose: bool, debug: bool) -> No
                 print("       Output:", block.output)
 
             shell.sendline(block.command)
-            shell.expect(re.escape(block.command))
+            for command_line in block.command.splitlines():
+                shell.expect_exact(command_line)
 
             # we expect the prompt of the next command unless there's no more
             if index + 1 < len(session.blocks):

--- a/src/tesh/tests/fixtures/multiline_command.md
+++ b/src/tesh/tests/fixtures/multiline_command.md
@@ -1,0 +1,8 @@
+# Multi-line command with `> ` following the prompt
+
+```console tesh-session="readme-example"
+$ echo "Hello from" \
+>   "another" \
+>   "line!"
+Hello from another line!
+```

--- a/src/tesh/tests/test_tesh.py
+++ b/src/tesh/tests/test_tesh.py
@@ -302,3 +302,22 @@ def test_long_commands() -> None:
     # fmt: on
 
     assert expected == result.output
+
+
+def test_multiline_command() -> None:
+    """Test using `> ` to extend a command across more than one line."""
+    runner = CliRunner()
+    result = runner.invoke(tesh, "src/tesh/tests/fixtures/multiline_command.md")
+
+    assert result.exit_code == 0
+
+    # fmt: off
+    expected = (
+"""
+📄 Checking src/tesh/tests/fixtures/multiline_command.md
+  ✨ Running readme-example  ✅ Passed
+"""
+    ).lstrip("\n")
+    # fmt: on
+
+    assert expected == result.output


### PR DESCRIPTION
With this PR, commands can extend across more than one line, by using `> ` as a continuation marker at the start of the lines following the prompt.

I found I needed to use multi-line commands in my own project using tesh.