### PR TITLE
fix: respect leading whitespace in example output

### DIFF
--- a/src/tesh/extract.py
+++ b/src/tesh/extract.py
@@ -186,7 +186,7 @@ def extract_blocks(session: ShellSession, verbose: bool) -> None:
         elif not line.strip():
             continue
         else:
-            new_block.output.append(line.strip())
+            new_block.output.append(line.rstrip("\n"))
     blocks.append(new_block)
     session.blocks = blocks
 

--- a/src/tesh/test.py
+++ b/src/tesh/test.py
@@ -38,7 +38,7 @@ def test(filename: str, session: ShellSession, verbose: bool, debug: bool) -> No
 
             shell.sendline(block.command)
             for command_line in block.command.splitlines():
-                shell.expect_exact(command_line)
+                shell.expect_exact(command_line + "\r\n")
 
             # we expect the prompt of the next command unless there's no more
             if index + 1 < len(session.blocks):
@@ -93,7 +93,7 @@ def test(filename: str, session: ShellSession, verbose: bool, debug: bool) -> No
 def get_actual_output(shell: pexpect.spawn) -> str:
     """Massage shell output to be able to compare it."""
     assert isinstance(shell.before, str)
-    actual_output = shell.before.strip().replace("\r\n", "\n")
+    actual_output = shell.before.rstrip().replace("\r\n", "\n")
     return "\n".join([line.rstrip() for line in actual_output.split("\n")])
 
 

--- a/src/tesh/tests/fixtures/whitespace.md
+++ b/src/tesh/tests/fixtures/whitespace.md
@@ -1,0 +1,49 @@
+# Whitespace handling in tesh code blocks
+
+Leading whitespace in command output is matched
+
+## Code block flush with left margin
+
+```console tesh-session="non-indented-block"
+$ # No blank lines after these commands:
+$ printf '0 space\n  2 space\n    4 space\n'
+0 space
+  2 space
+    4 space
+$ printf '  2 space\n    4 space\n0 space\n'
+  2 space
+    4 space
+0 space
+```
+
+## Code block with indent
+
+Leading whitespace is trimmed to the same level as the first line in the block.
+
+(The same example as above, but indented.)
+
+  ```console tesh-session="indented-block"
+    $ # No blank lines after these commands:
+    $ printf '0 space\n  2 space\n    4 space\n'
+    0 space
+      2 space
+        4 space
+    $ printf '  2 space\n    4 space\n0 space\n'
+      2 space
+        4 space
+    0 space
+  ```
+
+## Examples can have extra trailing whitespace for readability
+
+```console tesh-session="extra-trailing-whitespace"
+$ echo this is the first thing
+this is the first thing
+
+$ # This is some commentary on the next thing
+$ echo another thing
+another thing
+
+
+$ # More than one blank line is OK too.
+```

--- a/src/tesh/tests/test_tesh.py
+++ b/src/tesh/tests/test_tesh.py
@@ -340,3 +340,27 @@ def test_wildcards() -> None:
     # fmt: on
 
     assert expected == result.output
+
+
+def test_whitespace() -> None:
+    """Test code blocks with whitespace.
+
+    Both whitespace in command output, and indented code blocks.
+    """
+    runner = CliRunner()
+    result = runner.invoke(tesh, "src/tesh/tests/fixtures/whitespace.md")
+
+    assert result.exit_code == 0
+
+    # fmt: off
+    expected = (
+"""
+📄 Checking src/tesh/tests/fixtures/whitespace.md
+  ✨ Running non-indented-block  ✅ Passed
+  ✨ Running indented-block  ✅ Passed
+  ✨ Running extra-trailing-whitespace  ✅ Passed
+"""
+    ).lstrip("\n")
+    # fmt: on
+
+    assert expected == result.output


### PR DESCRIPTION
Previously indented output was not matched correctly, because whitespace was not stripped consistently when parsing examples and parsing output. We now only strip trailing whitespace from examples and actual output, so all leading whitespace is maintained and must match.

---

BTW, as I'm accumulating quite a few PRs now, these are starting to touch the same areas. This PR will merge conflict with #41 . I've got a branch in my repo with all of the PRs integrated in order: https://github.com/OceanSprint/tesh/compare/main...h4l:tesh:h4ls-patches