### PR TITLE
Example for nix-shell

### DIFF
--- a/demo/nix-shell.md
+++ b/demo/nix-shell.md
@@ -1,0 +1,10 @@
+# `nix-shell` example
+
+```console tesh-session="nix-shell" tesh-ps1="[nix-shell:~]$" tesh-timeout="300"
+$ echo $IN_NIX_SHELL
+$ export NIX_PATH=nixpkgs=https://github.com/nixos/nixpkgs/archive/c7a18f89ef1dc423f57f3de9bd5d9355550a5d15.tar.gz
+$ echo '{ pkgs ? import <nixpkgs> {} }: pkgs.mkShell { }' > shell.nix
+$ nix-shell
+[nix-shell:~]$ echo $IN_NIX_SHELL
+impure
+```


### PR DESCRIPTION
I was trying to use `tesh` to test some of my code example in markdown, but I couldn't get `nix-shell` to work. I think I'm missing something obvious.

I've added the minimal demo where I try to use `nix-shell`.

You can run it by:

```console
$ poetry run tesh demo/nix-shell.md
```